### PR TITLE
Replace deprecated mail_send() funtion by Mailer

### DIFF
--- a/action.php
+++ b/action.php
@@ -263,14 +263,16 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
              return false; 
         } 
      
-        global $conf;
-        
         $text = $this->getLang('email_confirm')  . "\n\n";
         $text .= $url;
         $text .= "\n\n";      
         $subject =$this->getLang('subject_confirm');
-        return mail_send($email, $subject . $conf['title'],$text, $conf['mailfrom']);
         
+        $mail = new Mailer();
+        $mail->to($email);
+        $mail->subject($subject);
+        $mail->setBody($text);
+        return $mail->send();
 }
 
 function is_user($uname) {

--- a/action.php
+++ b/action.php
@@ -264,14 +264,13 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
         } 
      
         $text = $this->getLang('email_confirm')  . "\n\n";
-        $text .= $url;
-        $text .= "\n\n";      
+        $text .= "@URL@\n\n";      
         $subject =$this->getLang('subject_confirm');
         
         $mail = new Mailer();
         $mail->to($email);
         $mail->subject($subject);
-        $mail->setBody($text);
+        $mail->setBody($text, array('url'=>$url));
         return $mail->send();
 }
 


### PR DESCRIPTION
Sending mail with `mail_send()` is deprecated and replaced by the Mailer class since 2012.

This plugin triggers a fatal error when used with the [smtp plugin](https://www.dokuwiki.org/plugin:smtp) due to the usage of the `mail_send()` function, which is fixed by using the Mailer class.