### PR TITLE
Added recaptcha2 plugin support

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,6 +19,7 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
      */
     private $metaFn;
     private $captcha;
+    private $captchaPlugins = array('captcha', 'recaptcha2');
     
     function register(Doku_Event_Handler $controller){
             $controller->register_hook('HTML_REGISTERFORM_OUTPUT', 'BEFORE', $this, 'update_register_form');
@@ -36,11 +37,15 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
          global $ACT;
          if($ACT !== 'register') return;        
          
-         if($this->captcha == 'none' || $this->captcha == 'builtin')  { 
-            ptln( "\n<style type='text/css'>\n   /*<![CDATA[*/");
+         if($this->captcha != 'captcha') {
+            ptln("\n<style type='text/css'>\n   /*<![CDATA[*/");
             ptln("#plugin__captcha_wrapper{ display:none; }\n   /*]]>*/\n</style>");
-         }   
-
+         }
+         
+         if($this->captcha != 'recaptcha2') {
+            ptln("\n<style type='text/css'>\n   /*<![CDATA[*/");
+            ptln("div.g-recaptcha{ display:none !important; }\n   /*]]>*/\n</style>");
+         }
     }    
     
         
@@ -73,32 +78,14 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
              msg('missing Real Name: please fill out all fields');
             return;
           }
-
-        if($this->captcha =='captcha') {         
-            $captcha = $this->loadHelper('captcha', true);
-            if(!$captcha->check()) {
-               return;
-            }
+        
+        if(!$this->captcha_succeeded()) {
+            ptln('<div class="error">'.$this->getLang('captcha_failed').'</div>');
+            return;
         }
          
-         if($this->is_user($_REQUEST['login']))  return;  // name already taken
-         if($this->captcha == 'builtin') {
-             $failed = false;
-             if(!isset($_REQUEST['card'])) {
-               echo '<h4>'. $this->getLang('cards_nomatch') . '</h4>';
-               return;
-             }
-             foreach($_REQUEST['card'] as $card) {          
-                 if(strpos($_REQUEST['sel'],$card) === false) {
-                     $failed = true;
-                     break;                
-                 }
-              }
-             if($failed) {    
-                 echo '<h4>'. $this->getLang('cards_nomatch') . '</h4>';
-                 return;
-            }
-        }
+        if($this->is_user($_REQUEST['login']))  return;  // name already taken
+        
         $t = time();
         $salt =  auth_cookiesalt();       
         $index = md5(microtime() .  $salt);
@@ -123,7 +110,33 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
           $data[$index]['savetime'] = $t;
           io_saveFile($this->metaFn,serialize($data));
     }
-  
+    
+    function captcha_succeeded() {
+        $success = false;
+        
+        if($this->captcha == 'none') {
+            $success = true;
+        }
+        else if($this->captcha == 'builtin' && isset($_REQUEST['card'])) {
+            $success = true;
+            
+            foreach($_REQUEST['card'] as $card) {
+                if(strpos($_REQUEST['sel'], $card) === false) {
+                    $success = false;
+                    break;
+                }
+            }
+        }
+        else if($this->captcha == 'captcha') {
+            $success = $this->loadHelper('captcha', true)->check();
+        }
+        else if($this->captcha == 'recaptcha2') {
+            $success = $this->loadHelper('recaptcha2', true)->check()->isSuccess();
+        }
+        
+        return $success;
+    }
+    
     function update_register_form(&$event, $param) {    
         if($_SERVER['REMOTE_USER']){
             return;
@@ -167,26 +180,23 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
            }
           
     }
-
- 
+    
     function check_captcha_selection() {
-       $list = plugin_list();
-       $this->captcha = $this->getConf('captcha');     
-       if(!in_array('captcha', $list)) {
-           if(preg_match("/captcha/", $this->captcha)) {                           
-               $this->captcha = 'builtin';
-           }
-           return;
-       }    
-       if($this->captcha == 'none' || $this->captcha == 'builtin')  { 
-           return;
-       }
-      if(plugin_isdisabled('captcha')) {
-          $this->captcha = 'builtin';
-          return;             
-      }
-      $this->captcha ='captcha';     
-       
+        $list = plugin_list();
+        $this->captcha = explode(" plugin", $this->getConf('captcha'))[0];
+        
+        if($this->captcha == 'none' || $this->captcha == 'builtin')  {
+            return;
+        }
+        
+        if(    in_array($this->captcha, $this->captchaPlugins)
+            && in_array($this->captcha, $list)
+            && !plugin_isdisabled($this->captcha)) {
+            
+            return;
+        }
+        
+        $this->captcha ='builtin';
     }
     
     /**

--- a/action.php
+++ b/action.php
@@ -80,7 +80,10 @@ class action_plugin_preregister extends DokuWiki_Action_Plugin {
           }
         
         if(!$this->captcha_succeeded()) {
-            ptln('<div class="error">'.$this->getLang('captcha_failed').'</div>');
+            if ($this->captcha == 'builtin') {
+                echo '<div class="error">'.$this->getLang('cards_nomatch').'</div>';
+            }
+            
             return;
         }
          

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,5 +1,5 @@
 <?php
 #$meta['captcha'] = array('onoff');
-$meta['captcha']  = array('multichoice','_choices' => array('builtin','captcha plugin','none'));
+$meta['captcha']  = array('multichoice','_choices' => array('builtin','captcha plugin','recaptcha2','none'));
 $meta['send_confirm'] = array('onoff');
 $meta['list_age'] = array('numeric');

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -5,6 +5,6 @@
  * 
  * @author Matthias Schulte <dokuwiki@lupo49.de>
  */
-$lang['captcha']               = 'CAPTCHA. Verfügbare Werte sind \'none\', \'builtin\' und \'captcha plugin\' (das Captcha-Plugin muss installiert sein. Wenn das nicht der Fall ist, wird es durch \'builtin\' ersetzt.)';
+$lang['captcha']               = 'CAPTCHA. Verfügbare Werte sind \'none\', \'builtin\', \'captcha plugin\', und \'recaptcha2\' (das Captcha-Plugin muss installiert sein. Wenn das nicht der Fall ist, wird es durch \'builtin\' ersetzt.)';
 $lang['send_confirm']          = 'Bestätigungslink per E-Mail versenden. Wenn \'false\' aktiv ist, wird der Link im Browser angezeigt.';
 $lang['list_age']              = 'Zeitraum, in dem die nicht bestätigten IDs gespeichert werden sollen, bevor sie verfallen. Der Standard ist zwei Tage (2*24*60*60). Über die Wiki-Administrationsoberfläche können Einträge entfernt werden.';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -5,6 +5,6 @@
  * 
  * @author Matthias Schulte <dokuwiki@lupo49.de>
  */
-$lang['captcha']               = 'CAPTCHA. Verfügbare Werte sind \'none\', \'builtin\' und \'captcha plugin\' (das Captcha-Plugin muss installiert sein. Wenn das nicht der Fall ist, wird es durch \'builtin\' ersetzt.)';
+$lang['captcha']               = 'CAPTCHA. Verfügbare Werte sind \'none\', \'builtin\', \'captcha plugin\', und \'recaptcha2\' (das Captcha-Plugin muss installiert sein. Wenn das nicht der Fall ist, wird es durch \'builtin\' ersetzt.)';
 $lang['send_confirm']          = 'Bestätigungslink per E-Mail versenden. Wenn \'false\' aktiv ist, wird der Link im Browser angezeigt.';
 $lang['list_age']              = 'Zeitraum, in dem die nicht bestätigten IDs gespeichert werden sollen, bevor sie verfallen. Der Standard ist zwei Tage (2*24*60*60). Über die Wiki-Administrationsoberfläche können Einträge entfernt werden.';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -5,7 +5,6 @@ $lang['uid_inuse'] = "userid is already in use: ";
 
 $lang['registering'] ="Registering: ";
 $lang['cards_nomatch'] = "Your Selections do not match the cards; please try again.";
-$lang['captcha_failed'] = "Please complete the CAPTCHA correctly to continue.";
 $lang['confirmation'] ="An email with a confirmation link has been sent to your email address.  Either click on that link or paste it "
               . " into your browser.  You will then be registered and will receive your password. ";
 $lang['email_problem'] ="A problem occurred in sending your confirmation link to your email address. You might try again later.";

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -5,6 +5,7 @@ $lang['uid_inuse'] = "userid is already in use: ";
 
 $lang['registering'] ="Registering: ";
 $lang['cards_nomatch'] = "Your Selections do not match the cards; please try again.";
+$lang['captcha_failed'] = "Please complete the CAPTCHA correctly to continue.";
 $lang['confirmation'] ="An email with a confirmation link has been sent to your email address.  Either click on that link or paste it "
               . " into your browser.  You will then be registered and will receive your password. ";
 $lang['email_problem'] ="A problem occurred in sending your confirmation link to your email address. You might try again later.";

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,4 +1,4 @@
 <?php
-$lang['captcha'] = "CAPTCHA. Choices are 'none', 'builtin', and 'captcha plugin', If 'captcha plugin' is selected then it must be installed; if it is not found the builtin will be substituted.";
+$lang['captcha'] = "CAPTCHA. Choices are 'none', 'builtin', 'captcha plugin', and 'recaptcha2'.  If 'captcha plugin' or 'recaptcha2' is selected, then it must be installed; if it is not found the builtin will be substituted.";
 $lang['send_confirm'] = "Send confirmation link to email address.  If set to false, the link will be printed to the screen.";
 $lang['list_age'] = "Length of time to save confirmation entries which have not been activated. Default is two days (2*24*60*60). Deletions are made using the plugin's admin panel.";

--- a/lang/eo/settings.php
+++ b/lang/eo/settings.php
@@ -5,6 +5,6 @@
  * 
  * @author Felipe Castro <fefcas@gmail.com>
  */
-$lang['captcha']               = 'CAPTCHA. Elektoj estas \'none\', \'builtin\', kaj \'captcha plugin\'; se \'captcha plugin\' estas elektata, do ĝi devas esti instalita; se ĝi ne estos trovata, la \'builtin\' anstataŭos.';
+$lang['captcha']               = 'CAPTCHA. Elektoj estas \'none\', \'builtin\', \'captcha plugin\', kaj \'recaptcha2\'; se \'captcha plugin\' aŭ \'recaptcha2\' estas elektata, do ĝi devas esti instalita; se ĝi ne estos trovata, la \'builtin\' anstataŭos.';
 $lang['send_confirm']          = 'Sendi konfirman ligon al retadreso. Se malaktiva, la ligo estos montrata sur la ekrano.';
 $lang['list_age']              = 'Kvanto da tempo por konservi konfirmaj enigoj kiuj ne estis aktivataj. Apriore ni uzas du tagojn (2*24*60*60). Forigoj estas plenumataj per la administrilo de la kromaĵo.';

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -5,6 +5,6 @@
  * 
  * @author Schplurtz le Déboulonné <schplurtz@laposte.net>
  */
-$lang['captcha']               = 'CAPTCHA. Les choix possibles sont "none" (aucun), "builtin" (interne) et "captcha plugin" (extension captcha). Pour choisir "extension captcha", il faut que cette dernière soit installée; si elle n\'est pas détectée, la valeur "interne" sera utilisée à la place.';
+$lang['captcha']               = 'CAPTCHA. Les choix possibles sont "none" (aucun), "builtin" (interne), "captcha plugin" (extension captcha), et "recaptcha2" (extension recaptcha2). Pour choisir "extension captcha" ou "extension recaptcha2", il faut que cette dernière soit installée; si elle n\'est pas détectée, la valeur "interne" sera utilisée à la place.';
 $lang['send_confirm']          = 'Envoyer le lien de confirmation à l\'adresse de courriel. Si désactivé, le lien s\'affiche à l\'écran.';
 $lang['list_age']              = 'Durée de conservation en secondes des données de confirmation qui n\'ont pas été activées. La valeur par défaut est deux jours (2*24*60*60). Le panneau d\'administration permet d\'effectuer des suppressions.';

--- a/lang/nl/settings.php
+++ b/lang/nl/settings.php
@@ -5,6 +5,6 @@
  * 
  * @author rene <wllywlnt@yahoo.com>
  */
-$lang['captcha']               = 'CAPTCHA. Keuzen zijn  \'none\', \'builtin\', en \'captcha plugin\', Indien \'captcha plugin\' wordt geselecteerd dan moet deze geïnstalleerd zijn; indien niet gevonden dan wordt deze vervangen.';
+$lang['captcha']               = 'CAPTCHA. Keuzen zijn  \'none\', \'builtin\', \'captcha plugin\', en \'recaptcha2\'. Indien \'captcha plugin\' of \'recaptcha2\' wordt geselecteerd dan moet deze geïnstalleerd zijn; indien niet gevonden dan wordt deze vervangen.';
 $lang['send_confirm']          = 'Stuur bevestigings link naar het e-mailadres. Indien onwaar zal de link worden getoond. ';
 $lang['list_age']              = 'Tijdsbestek om niet geactiveerde bevestigings gegevens te bewaren. Standaard is dit twee dagen (2*24*60*60).Verwijderingen worden via het administratie scherm van de plugin uitgevoerd.';

--- a/lang/pt-br/settings.php
+++ b/lang/pt-br/settings.php
@@ -5,6 +5,6 @@
  * 
  * @author Felipe Castro <fefcas@gmail.com>
  */
-$lang['captcha']               = 'CAPTCHA. Escolhas são \'none\', \'builtin\', e \'captcha plugin\'. Se for selecionado \'captcha plugin\' então ele deve estar instalado; se ele não for encontrado o \'bultin\' será o substituto.';
+$lang['captcha']               = 'CAPTCHA. Escolhas são \'none\', \'builtin\', \'captcha plugin\', e \'recaptcha2\'. Se for selecionado \'captcha plugin\' ou \'recaptcha2\' então ele deve estar instalado; se ele não for encontrado o \'bultin\' será o substituto.';
 $lang['send_confirm']          = 'Enviar linque de confirmação para endereço de emeil. Se não estiver ativado, o linque será mostrado na tela.';
 $lang['list_age']              = 'Tempo para salvar entradas de confirmação que não foram ativadas. Por padrão usa-se dois dias (2*24*60*60). Exclusões são feitas pelo painel de administração da extensão.';


### PR DESCRIPTION
Added [`recaptcha2` plugin](https://www.dokuwiki.org/plugin:recaptcha2) support so that using `preregister` and `recaptcha2` in tandem works correctly.  Without this change, `recaptcha2`'s CAPTCHA is ignored during registration and `preregister`'s own CAPTCHA may appear alongside it, depending on settings.

I also attempted to update the localized admin panel strings to acknowledge `recaptcha2` as a valid option, but I don't speak any of these languages and couldn't make a educated guess for Japanese.  It might be worth getting an actual speaker to proofread them, if possible.

The previous pull request introduced a bug that caused the original `captcha` plugin to not work correctly, resulting in `builtin` always being substituted in.  This version does not have that problem.