### PR TITLE
Fix "Array and string offset access syntax with curly braces is no longer supported"

### DIFF
--- a/action.php
+++ b/action.php
@@ -310,7 +310,7 @@ function is_user($uname) {
     $uname = utf8_strtolower($uname);
     foreach($users as $line) {
         $line = trim($line);
-        if($line{0} == '#') continue;
+        if($line[0] == '#') continue;
         list($user,$rest) = preg_split('/:/',$line,2);
         if(!trim($user)) continue;
         if($uname == $user) {


### PR DESCRIPTION
Fixes this error causing a 500 Server Error with PHP 8.1:

```
[Tue Jan 25 04:56:55.322564 2022] [php:error] [pid 6779] [client 127.0.0.1:40926] PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /var/lib/dokuwiki/lib/plugins/preregister/action.php on line 313
```